### PR TITLE
Update dependency in order to require retailer-offer's latest releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "magento/framework": "*",
     "magento/module-store": "*",
     "magento/module-checkout": "*",
-    "smile/module-retailer-offer": "~1.7.0"
+    "smile/module-retailer-offer": "~1.7"
   },
   "require-dev": {
     "smile/magento2-smilelab-quality-suite": "^1.0.5"


### PR DESCRIPTION
Hi,

We're trying to upgrade to Magento 2.4 and we need this fix which is available in the 1.8.0 release https://github.com/Smile-SA/magento2-module-retailer-offer/pull/61/commits/3138b31c60878025315c42926989fd9d2796d573

To do so, we need to update the requirements of the module Smile_RetailerOffer, so here's my proposal 

Regards